### PR TITLE
Fix index creation

### DIFF
--- a/dbt/models/marts/_wind_solar__models.yml
+++ b/dbt/models/marts/_wind_solar__models.yml
@@ -4,14 +4,13 @@ models:
       materialized: incremental
       schema: mart
       alias: wind_and_solar_generation
-      unique_key: ['start_time', 'psr_type'] # composite key for dbt merge
-      indexes:
-        - columns: ['start_time', 'psr_type']
-          unique: true
+      unique_key: ['start_time', 'psr_type'] # tells dbt how to merge incremental rows - composite key
       incremental_strategy: merge
       tags: ["wind_solar"]
+      post_hook:
+        - "create unique index if not exists wind_and_solar_generation_start_time_psr_type_idx on {{ this }} (start_time, psr_type)"
     description: Final mart containing the latest generation quantity by start time and PSR type.
-    # Validate that the final mart keeps one row per event interval and generation type.
+    # Validate composite uniqueness.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/dbt/models/staging/stg_wind_solar.sql
+++ b/dbt/models/staging/stg_wind_solar.sql
@@ -5,8 +5,7 @@ select
     window_to_utc,
     request_url,
     http_status,
-    payload_json::jsonb as payload_json,
-    load_date
+    payload_json::jsonb as payload_json
 from {{ source('ingestion', 'wind_and_solar_power_generation') }}
 where
     payload_json is not null


### PR DESCRIPTION
## 🚀 Description
`dbt/models/marts/_wind_solar__models.yml` failed to crate index.

Fixes #71 

## 🧪 How Has This Been Tested?
Check if the  `mart.wind_and_solar_generation` table index is available
